### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,10 +22,12 @@ class TablesPlugin {
           verbose: {
             usage: 'Verbose output',
             shortcut: 'v',
+            type: 'boolean',
           },
           debug: {
             usage: 'Debug the plugin',
             shortcut: 'd',
+            type: 'boolean',
           },
         },
         commands: {


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - TablesPlugin for "verbose", "debug"
```